### PR TITLE
Generic validating value

### DIFF
--- a/Example/Tests/ObjectTests.swift
+++ b/Example/Tests/ObjectTests.swift
@@ -10,9 +10,10 @@ import XCTest
 import URBNValidator
 
 class Testable: Validateable {
-    var rules = [String: ValidatingValue]()
+    typealias V = Any
+    var rules = [String: ValidatingValue<V>]()
     
-    func validationMap() -> [String : ValidatingValue] {
+    func validationMap() -> [String : ValidatingValue<V>] {
         return rules
     }
 }
@@ -22,7 +23,7 @@ class User: Testable {
     var lastName: String?
     var addresses = [String]()
     
-    override func validationMap() -> [String : ValidatingValue] {
+    override func validationMap() -> [String : ValidatingValue<V>] {
         rules = rules.count > 0 ? rules : [
             "firstName": ValidatingValue(value: self.firstName, rules: URBNRequiredRule(), URBNMinLengthRule(minLength: 2, inclusive: true)),
             "lastName": ValidatingValue(value: self.lastName, rules: URBNNotRequiredRule(), URBNMinLengthRule(minLength: 2, inclusive: true)),

--- a/Example/Tests/ObjectTests.swift
+++ b/Example/Tests/ObjectTests.swift
@@ -10,7 +10,7 @@ import XCTest
 import URBNValidator
 
 class Testable: Validateable {
-    typealias V = Any
+    typealias V = Lengthable
     var rules = [String: ValidatingValue<V>]()
     
     func validationMap() -> [String : ValidatingValue<V>] {
@@ -23,13 +23,21 @@ class User: Testable {
     var lastName: String?
     var addresses = [String]()
     
-    override func validationMap() -> [String : ValidatingValue<V>] {
-        rules = rules.count > 0 ? rules : [
-            "firstName": ValidatingValue(value: self.firstName, rules: URBNRequiredRule(), URBNMinLengthRule(minLength: 2, inclusive: true)),
-            "lastName": ValidatingValue(value: self.lastName, rules: URBNNotRequiredRule(), URBNMinLengthRule(minLength: 2, inclusive: true)),
-            "addresses": ValidatingValue(value: self.addresses, rules: URBNNotRequiredRule(), URBNMinLengthRule(minLength: 1, inclusive: true))
-        ]
-        return super.validationMap()
+    override var rules: [String: ValidatingValue<V>] {
+        get {
+            if super.rules.isEmpty {
+                super.rules = [
+                    "firstName": ValidatingValue(value: self.firstName, rules: URBNRequiredRule(), URBNMinLengthRule(minLength: 2, inclusive: true)),
+                    "lastName": ValidatingValue(value: self.lastName, rules: URBNNotRequiredRule(), URBNMinLengthRule(minLength: 2, inclusive: true)),
+                    "addresses": ValidatingValue(value: self.addresses, rules: URBNNotRequiredRule(), URBNMinLengthRule(minLength: 1, inclusive: true))
+                ]
+            }
+            
+            return super.rules
+        }
+        set {
+            super.rules = newValue
+        }
     }
 }
 

--- a/Pod/Classes/ObjC/URBNValidatorCompat.swift
+++ b/Pod/Classes/ObjC/URBNValidatorCompat.swift
@@ -22,8 +22,8 @@ import Foundation
 }
 
 extension CompatValidateable {
-    func backingValidationMap() -> [String: ValidatingValue] {
-        return validationMap().reduce([String: ValidatingValue]()) { (var dict, items: (key: String, value: CompatValidatingValue)) -> [String: ValidatingValue] in
+    func backingValidationMap() -> [String: ValidatingValue<AnyObject>] {
+        return validationMap().reduce([String: ValidatingValue<AnyObject>]()) { (var dict, items: (key: String, value: CompatValidatingValue)) -> [String: ValidatingValue<AnyObject>] in
             dict[items.key] = items.value.backingRules()
             return dict
         }
@@ -47,13 +47,14 @@ extension CompatValidateable {
 }
 
 class ConvertCompat: Validateable {
-    var rules = [String: ValidatingValue]()
+    typealias V = AnyObject
+    var rules = [String: ValidatingValue<V>]()
     
     init(cv: CompatValidateable) {
         rules = cv.backingValidationMap()
     }
     
-    func validationMap() -> [String : ValidatingValue] {
+    func validationMap() -> [String : ValidatingValue<V>] {
         return rules
     }
 }
@@ -74,7 +75,7 @@ class ConvertCompat: Validateable {
 }
 
 extension CompatValidatingValue {
-    func backingRules() -> ValidatingValue {
+    func backingRules() -> ValidatingValue<AnyObject> {
         let mrules = rules.map { $0.backingRule as ValidationRule }
         let v = ValidatingValue(value, rules: mrules)
         

--- a/Pod/Classes/URBNLengthRules.swift
+++ b/Pod/Classes/URBNLengthRules.swift
@@ -9,48 +9,48 @@
 import Foundation
 
 
-protocol Lengthable {
+public protocol Lengthable {
     var length: Int { get }
 }
 
 extension String: Lengthable {
-    var length: Int {
+    public var length: Int {
         return self.characters.count
     }
 }
 extension NSString: Lengthable {}
 extension Array: Lengthable {
-    var length: Int {
+    public var length: Int {
         return self.count
     }
 }
 
 extension NSArray: Lengthable {
-    var length: Int {
+    public var length: Int {
         return self.count
     }
 }
 
 extension Dictionary: Lengthable {
-    var length: Int {
+    public var length: Int {
         return self.count
     }
 }
 
 extension NSDictionary: Lengthable {
-    var length: Int {
+    public var length: Int {
         return self.count
     }
 }
 
 extension NSTimeInterval: Lengthable {
-    var length: Int {
+    public var length: Int {
         return Int(self)
     }
 }
 
 extension NSNumber: Lengthable {
-    var length: Int {
+    public var length: Int {
         return self.integerValue;
     }
 }

--- a/Pod/Classes/URBNValidator.swift
+++ b/Pod/Classes/URBNValidator.swift
@@ -9,16 +9,16 @@
 import Foundation
 
 
-public class ValidatingValue {
-    public var value: Any?
+public class ValidatingValue<V> {
+    public var value: V?
     public var rules: [ValidationRule]
     
-    public init(_ value: Any?, rules: [ValidationRule]) {
+    public init(_ value: V?, rules: [ValidationRule]) {
         self.value = value
         self.rules = rules
     }
     
-    public convenience init(value: Any?, rules: ValidationRule...) {
+    public convenience init(value: V?, rules: ValidationRule...) {
         self.init(value, rules: rules)
     }
 }
@@ -40,7 +40,8 @@ public protocol Validator {
  defining a validationMap which contains a map of keys -> ValidatingValue's
 */
 public protocol Validateable {
-    func validationMap() -> [String: ValidatingValue]
+    typealias V
+    func validationMap() -> [String: ValidatingValue<V>]
 }
 
 /**


### PR DESCRIPTION
this adds a generic to the validating value. it is currently `Any` which works ok, but since this is a pretty simple change I thought it might be nice to use the generic

the test that this affects could specify `Any` but since they're all `lengthable` it seemed like a good idea to make `lengthable` public so the `validateable` could be `lengthable` and not `any`
