### PR TITLE
Tweak

### DIFF
--- a/Example/Tests/ObjectTests.swift
+++ b/Example/Tests/ObjectTests.swift
@@ -41,6 +41,39 @@ class User: Testable {
     }
 }
 
+struct TestItem: Validateable {
+    typealias V = AnyObject
+    var prop1: String
+    
+    
+    func validationMap() -> [String : ValidatingValue<V>] {
+        return [
+            "prop1": ValidatingValue(value: self.prop1, rules: URBNNotRequiredRule(), URBNRegexRule(pattern: "(?<![a-z-#.\\d\\p{Latin}])[a-z-#.\\d\\p{Latin}][a-z-#.\\d\\s\\p{Latin}]+"))
+        ]
+    }
+}
+class ValidatorTests: XCTestCase {
+    
+    
+    func testNotRequired () {
+        
+        let vd = URBNValidator()
+        let item = TestItem(prop1: "")
+        
+        var error: NSError? = nil
+        do {
+            try vd.validate(item)
+        } catch let err as NSError {
+            error = err
+        }
+        XCTAssertEqual(error!.domain, ValidationErrorDomain, "Should be ValidationErrorDomain")
+        XCTAssertEqual(error!.code, ValidationError.MultiFieldInvalid.rawValue, "Should be single field error type")
+    }
+    
+    
+    
+}
+
 class ObjectTestsSwifty: XCTestCase {
     var vd = URBNValidator()
     

--- a/Example/Tests/ObjectTests.swift
+++ b/Example/Tests/ObjectTests.swift
@@ -52,9 +52,7 @@ struct TestItem: Validateable {
         ]
     }
 }
-class ValidatorTests: XCTestCase {
-    
-    
+class ValidatorTests: XCTestCase {    
     func testNotRequired () {
         
         let vd = URBNValidator()
@@ -69,9 +67,6 @@ class ValidatorTests: XCTestCase {
         XCTAssertEqual(error!.domain, ValidationErrorDomain, "Should be ValidationErrorDomain")
         XCTAssertEqual(error!.code, ValidationError.MultiFieldInvalid.rawValue, "Should be single field error type")
     }
-    
-    
-    
 }
 
 class ObjectTestsSwifty: XCTestCase {

--- a/Pod/Classes/URBNValidator.swift
+++ b/Pod/Classes/URBNValidator.swift
@@ -31,7 +31,7 @@ public protocol Validator {
      If invalid, then will `throw` an error with the localized reason
      why the value failed
     **/
-    func validate<V>(key: String?, value: V?, rule: ValidationRule) throws
+    func validate<T>(key: String?, value: T?, rule: ValidationRule) throws
     func validate<V: Validateable>(item: V , stopOnFirstError: Bool) throws
 }
 
@@ -81,7 +81,7 @@ public class URBNValidator: Validator {
      
      - throws: An instance of NSError with the localized data
     */
-    public func validate<V>(key: String? = nil, value: V?, rule: ValidationRule) throws {
+    public func validate<T>(key: String? = nil, value: T?, rule: ValidationRule) throws {
         if rule.validateValue(value) {
             return
         }

--- a/Pod/Classes/URBNValidator.swift
+++ b/Pod/Classes/URBNValidator.swift
@@ -31,7 +31,7 @@ public protocol Validator {
      If invalid, then will `throw` an error with the localized reason
      why the value failed
     **/
-    func validate(key: String?, value: Any?, rule: ValidationRule) throws
+    func validate<V>(key: String?, value: V?, rule: ValidationRule) throws
     func validate<V: Validateable>(item: V , stopOnFirstError: Bool) throws
 }
 
@@ -81,7 +81,7 @@ public class URBNValidator: Validator {
      
      - throws: An instance of NSError with the localized data
     */
-    public func validate(key: String? = nil, value: Any?, rule: ValidationRule) throws {
+    public func validate<V>(key: String? = nil, value: V?, rule: ValidationRule) throws {
         if rule.validateValue(value) {
             return
         }


### PR DESCRIPTION
add a generic for the other `validate` method on validator. this is needed because `validator` calls through to the rule's `func validateValue<T>(value: T?) -> Bool` which is generic. 

if an `any` method calls to a generic one there's no type info and the matching breaks in a difficult to debug way
