### PR TITLE
Localization Fix

### DIFF
--- a/Example/Example/en.lproj/Localizable.strings
+++ b/Example/Example/en.lproj/Localizable.strings
@@ -7,4 +7,4 @@
 */
 
 
-"ls_URBNValidator_URBNRequiredRule_Override" = "What the hell";
+"URBNRequiredRule_Override" = "What the hell";

--- a/Example/Tests/BasicTests.swift
+++ b/Example/Tests/BasicTests.swift
@@ -7,7 +7,7 @@ class BasicTests: XCTestCase {
     func testRequiredRule() {
         let r = URBNRequiredRule()
         
-        XCTAssertEqual(r.localizationKey, "URBNValidator.URBNRequiredRule", "localizationKey should default to the className")
+        XCTAssertEqual(r.localizationKey, "ls_URBNValidator_URBNValidator.URBNRequiredRule", "localizationKey should default to the className")
         XCTAssertFalse(r.validateValue(nil as AnyObject?), "Nil should be invalid")
         XCTAssertTrue(r.validateValue("-"), "Non-nil should be valid")
     }
@@ -15,7 +15,7 @@ class BasicTests: XCTestCase {
     func testMinLengthRule() {
         let r = URBNMinLengthRule(minLength: 5, inclusive: true)
         
-        XCTAssertEqual(r.localizationKey, "URBNValidator.URBNMinLengthRule")
+        XCTAssertEqual(r.localizationKey, "ls_URBNValidator_URBNValidator.URBNMinLengthRule")
         XCTAssertFalse(r.validateValue("1234"))
         XCTAssertTrue(r.validateValue("12345"))
         
@@ -31,7 +31,7 @@ class BasicTests: XCTestCase {
     func testMaxLengthRule() {
         let r = URBNMaxLengthRule(maxLength: 5, inclusive: true)
         
-        XCTAssertEqual(r.localizationKey, "URBNValidator.URBNMaxLengthRule")
+        XCTAssertEqual(r.localizationKey, "ls_URBNValidator_URBNValidator.URBNMaxLengthRule")
         XCTAssertTrue(r.validateValue("1234"))
         XCTAssertFalse(r.validateValue("123456"))
         
@@ -49,7 +49,7 @@ class BasicTests: XCTestCase {
             return value is Int
         }
         
-        XCTAssertEqual(r.localizationKey, "URBNValidator.URBNBlockRule")
+        XCTAssertEqual(r.localizationKey, "ls_URBNValidator_URBNValidator.URBNBlockRule")
         XCTAssertFalse(r.validateValue(nil as AnyObject?))
         XCTAssertFalse(r.validateValue(0.1))
         XCTAssertTrue(r.validateValue(1))
@@ -58,7 +58,7 @@ class BasicTests: XCTestCase {
     func testDateRule() {
         let r = URBNDateRule()
         
-        XCTAssertEqual(r.localizationKey, "URBNValidator.URBNDatePastRule")
+        XCTAssertEqual(r.localizationKey, "ls_URBNValidator_URBNValidator.URBNDatePastRule")
         XCTAssertEqual(r.comparisonType, URBNDateComparision.Past, "Should default to past")
         
         r.comparisonType = URBNDateComparision.Past
@@ -78,7 +78,7 @@ class BasicTests: XCTestCase {
         let r = URBNRegexRule(pattern: "(?<![a-z-#.\\d\\p{Latin}])[a-z-#.\\d\\p{Latin}][a-z-#.\\d\\s\\p{Latin}]+")
         r.isRequired = false
         
-        XCTAssertEqual(r.localizationKey, "URBNValidator.URBNRegexRule")
+        XCTAssertEqual(r.localizationKey, "ls_URBNValidator_URBNValidator.URBNRegexRule")
         
         XCTAssertFalse(r.validateValue(""), "Should validate empty when required is off")
         XCTAssertFalse(r.validateValue(" "), "Should not validate")

--- a/Example/Tests/LocalizationTests.swift
+++ b/Example/Tests/LocalizationTests.swift
@@ -14,17 +14,17 @@ class LocalizationTests: XCTestCase {
     
     
     func testDefaultLocalizationKeys() {
-        XCTAssertEqual(URBNRequiredRule().localizationKey, "URBNValidator.URBNRequiredRule")
-        XCTAssertEqual(URBNMinLengthRule(minLength: 0).localizationKey, "URBNValidator.URBNMinLengthRule")
-        XCTAssertEqual(URBNMaxLengthRule(maxLength: 0).localizationKey, "URBNValidator.URBNMaxLengthRule")
-        XCTAssertEqual(URBNRegexRule(pattern: "").localizationKey, "URBNValidator.URBNRegexRule")
-        XCTAssertEqual(URBNRegexRule(patternType: .AlphaNumeric).localizationKey, "URBNValidator.URBNRegexRule")
-        XCTAssertEqual(URBNRegexRule(patternType: .Email).localizationKey, "URBNValidator.URBNRegexEmailRule")
-        XCTAssertEqual(URBNRegexRule(patternType: .Letters).localizationKey, "URBNValidator.URBNRegexLettersRule")
-        XCTAssertEqual(URBNRegexRule(patternType: .Numbers).localizationKey, "URBNValidator.URBNRegexNumbersRule")
-        XCTAssertEqual(URBNDateRule().localizationKey, "URBNValidator.URBNDatePastRule")
-        XCTAssertEqual(URBNDateRule(comparisonType: .Future).localizationKey, "URBNValidator.URBNDateFutureRule")
-        XCTAssertEqual(URBNBlockRule(validator: { _ in true }).localizationKey, "URBNValidator.URBNBlockRule")
+        XCTAssertEqual(URBNRequiredRule().localizationKey, "ls_URBNValidator_URBNValidator.URBNRequiredRule")
+        XCTAssertEqual(URBNMinLengthRule(minLength: 0).localizationKey, "ls_URBNValidator_URBNValidator.URBNMinLengthRule")
+        XCTAssertEqual(URBNMaxLengthRule(maxLength: 0).localizationKey, "ls_URBNValidator_URBNValidator.URBNMaxLengthRule")
+        XCTAssertEqual(URBNRegexRule(pattern: "").localizationKey, "ls_URBNValidator_URBNValidator.URBNRegexRule")
+        XCTAssertEqual(URBNRegexRule(patternType: .AlphaNumeric).localizationKey, "ls_URBNValidator_URBNValidator.URBNRegexRule")
+        XCTAssertEqual(URBNRegexRule(patternType: .Email).localizationKey, "ls_URBNValidator_URBNValidator.URBNRegexEmailRule")
+        XCTAssertEqual(URBNRegexRule(patternType: .Letters).localizationKey, "ls_URBNValidator_URBNValidator.URBNRegexLettersRule")
+        XCTAssertEqual(URBNRegexRule(patternType: .Numbers).localizationKey, "ls_URBNValidator_URBNValidator.URBNRegexNumbersRule")
+        XCTAssertEqual(URBNDateRule().localizationKey, "ls_URBNValidator_URBNValidator.URBNDatePastRule")
+        XCTAssertEqual(URBNDateRule(comparisonType: .Future).localizationKey, "ls_URBNValidator_URBNValidator.URBNDateFutureRule")
+        XCTAssertEqual(URBNBlockRule(validator: { _ in true }).localizationKey, "ls_URBNValidator_URBNValidator.URBNBlockRule")
     }
     
     func testDefaultLocalizationStrings() {
@@ -48,7 +48,7 @@ class LocalizationTests: XCTestCase {
     }
     
     
-    func testLocalizationOverrides() {
+    func testLocalizationOverrideKeys() {
         XCTAssertEqual(URBNRequiredRule(localizationKey: "Required").localizationKey, "Required")
         XCTAssertEqual(URBNMinLengthRule(minLength: 0, inclusive: true, localizationKey: "MinLength").localizationKey, "MinLength")
         XCTAssertEqual(URBNMaxLengthRule(maxLength: 0, inclusive: true, localizationKey: "MaxLength").localizationKey, "MaxLength")
@@ -59,4 +59,20 @@ class LocalizationTests: XCTestCase {
     }
     
     
+    func testLocalizationOverrideStrings() {
+        let vd = URBNValidator()
+        
+        let localizedError: (ValidationRule) -> String? = { (rule) -> String? in
+            return vd.localizeableString(rule, key: "test", value: "value")
+        }
+        
+        
+        XCTAssertEqual(localizedError(URBNRequiredRule(localizationKey: "Required")), "Required")
+        XCTAssertEqual(localizedError(URBNMinLengthRule(minLength: 0, inclusive: true, localizationKey: "MinLength")), "MinLength")
+        XCTAssertEqual(localizedError(URBNMaxLengthRule(maxLength: 0, inclusive: true, localizationKey: "MaxLength")), "MaxLength")
+        XCTAssertEqual(localizedError(URBNRegexRule(pattern: "", localizationKey: "Regex")), "Regex")
+        XCTAssertEqual(localizedError(URBNDateRule(comparisonType: .Past, localizationKey: "DateIsPast")), "DateIsPast")
+        XCTAssertEqual(localizedError(URBNDateRule(comparisonType: .Future, localizationKey: "DateIsFuture")), "DateIsFuture")
+        XCTAssertEqual(localizedError(URBNBlockRule(validator: { _ in true }, localizationKey: "CustomBlockFailed")), "CustomBlockFailed")
+    }
 }

--- a/Example/Tests/ObjectCompatTests.m
+++ b/Example/Tests/ObjectCompatTests.m
@@ -12,13 +12,15 @@
 @interface TestObject: NSObject <CompatValidateable>
 @property (nonatomic, copy) NSString *requiredString;
 @property (nonatomic, copy) NSArray *requiredList;
+@property (nonatomic, strong) id someObj;
 @end
 @implementation TestObject
 
 - (NSDictionary<NSString *,NSArray<URBNCompatBaseRule *> *> *)validationMap {
     return @{
              @"requiredString": [[CompatValidatingValue alloc] init:self.requiredString rules:@[URBNVRequired]],
-             @"requiredList": [[CompatValidatingValue alloc] init:self.requiredList rules:@[URBNVRequired, URBNVGreaterThanOrEqual(3)]]
+             @"requiredList": [[CompatValidatingValue alloc] init:self.requiredList rules:@[URBNVRequired, URBNVGreaterThanOrEqual(3)]],
+             @"someObj": [[CompatValidatingValue alloc] init:self.someObj rules:@[URBNVRequired]]
              };
 }
 
@@ -59,7 +61,18 @@
     XCTAssertEqualObjects(error.domain, ValidationErrorDomain, @"Error domain should be the invalid one");
     XCTAssertEqual(error.code, ValidationErrorMultiFieldInvalid, @"Multiple field error here");
     XCTAssertTrue([error isMultiError], @"We should get a multi-error if stopOnFirst is NO");
-    XCTAssertEqual([error underlyingErrors].count, 3, @"We should have 1 error for every invalid rule (3 in this case)");
+    XCTAssertEqual([error underlyingErrors].count, 4, @"We should have 1 error for every invalid rule (3 in this case)");
+}
+
+- (void)testNSNull {
+    TestObject *obj = [TestObject new];
+    obj.requiredString = @"1";
+    obj.requiredList = @[@1,@2,@3,@4];
+    obj.someObj = [NSNull null];
+    
+    NSError *error = nil;
+    BOOL success = [self.vd validate:obj stopOnFirstError:YES error:&error];
+    XCTAssertTrue(success);
 }
 
 @end

--- a/Example/Tests/ObjectTests.swift
+++ b/Example/Tests/ObjectTests.swift
@@ -134,8 +134,8 @@ class ObjectTestsSwifty: XCTestCase {
             XCTFail("Should not validate")
         } catch let err as NSError {
             XCTAssertEqual(err.underlyingErrors!.count, 2)
-            XCTAssertEqual(err.underlyingErrors![0].localizedDescription, "ls_URBNValidator_t_required")
-            XCTAssertEqual(err.underlyingErrors![1].localizedDescription, "ls_URBNValidator_t_integer")
+            XCTAssertEqual(err.underlyingErrors![0].localizedDescription, "t_required")
+            XCTAssertEqual(err.underlyingErrors![1].localizedDescription, "t_integer")
         }
     }
 }

--- a/Pod/Classes/URBNBaseRule.swift
+++ b/Pod/Classes/URBNBaseRule.swift
@@ -27,7 +27,7 @@ public class URBNBaseRule: ValidationRule {
                 return key
             }
             else {
-                return NSStringFromClass(self.dynamicType)
+                return "ls_URBNValidator_\(NSStringFromClass(self.dynamicType))"
             }
         }
         set {

--- a/Pod/Classes/URBNRegexRule.swift
+++ b/Pod/Classes/URBNRegexRule.swift
@@ -31,9 +31,9 @@ let numericPattern = "^[\\d]"
     
     var localizeString: String? {
         switch(self) {
-        case .Email: return "URBNValidator.URBNRegexEmailRule"
-        case .Letters: return "URBNValidator.URBNRegexLettersRule"
-        case .Numbers: return "URBNValidator.URBNRegexNumbersRule"
+        case .Email: return "ls_URBNValidator_URBNValidator.URBNRegexEmailRule"
+        case .Letters: return "ls_URBNValidator_URBNValidator.URBNRegexLettersRule"
+        case .Numbers: return "ls_URBNValidator_URBNValidator.URBNRegexNumbersRule"
         default: return nil
         }
     }

--- a/Pod/Classes/URBNValidationRules.swift
+++ b/Pod/Classes/URBNValidationRules.swift
@@ -74,8 +74,8 @@ public class URBNBlockRule: URBNBaseRule {
     
     var localizeString: String {
         switch(self) {
-        case .Past: return "URBNValidator.URBNDatePastRule"
-        case .Future: return "URBNValidator.URBNDateFutureRule"
+        case .Past: return "ls_URBNValidator_URBNValidator.URBNDatePastRule"
+        case .Future: return "ls_URBNValidator_URBNValidator.URBNDateFutureRule"
         }
     }
 }

--- a/Pod/Classes/URBNValidator.swift
+++ b/Pod/Classes/URBNValidator.swift
@@ -165,7 +165,7 @@ public class URBNValidator: Validator {
         - value: The value to inject into the localization (if applicable).  Replaces the {{value}}
     */
     internal func localizeableString(rule: ValidationRule, key: String?, value: Any?) -> String {
-        let ruleKey = "ls_URBNValidator_\(rule.localizationKey)"
+        let ruleKey = rule.localizationKey
         
         // First we try to localize against the mainBundle.
         let mainBundleStr = NSLocalizedString(ruleKey, tableName: self.localizationTable, comment: "")


### PR DESCRIPTION
Previously when using a localizationKey in conjunction with URBNValidator the localizationKey would be prefixes with `ls_URBNValidator_`.

The issue with this is when supplying a custom localization key, then you don't want it to be prefixed.

This PR fixes the issue by doing the prefixing internally in the rules instead of orchestrating at urbnvalidator level
